### PR TITLE
Allow a view to be a drag source and a drop zone

### DIFF
--- a/Classes/AtkDefaultDragAndDropManagerDelegate.m
+++ b/Classes/AtkDefaultDragAndDropManagerDelegate.m
@@ -47,8 +47,8 @@
 - (NSMutableArray *)findDropZones:(AtkDragAndDropManager *)manager view:(UIView *)view recognizer:(UIGestureRecognizer *)recognizer dropZones:(NSMutableArray *)dropZones
 {
     if([view conformsToProtocol:@protocol(AtkDropZoneProtocol)] &&
-       [view respondsToSelector:@selector(shouldDragStart:)] &&
-       [(id<AtkDropZoneProtocol>)view shouldDragStart:manager])
+       [view respondsToSelector:@selector(dropZoneShouldDragStart:)] &&
+       [(id<AtkDropZoneProtocol>)view dropZoneShouldDragStart:manager])
     {
         if(!dropZones)
             dropZones = [NSMutableArray array];
@@ -82,9 +82,9 @@
 {
     BOOL ret = false;
     
-    if([dropZone respondsToSelector:@selector(isActive:point:)])
+    if([dropZone respondsToSelector:@selector(dropZoneIsActive:point:)])
     {
-        ret = [dropZone isActive:manager point:[recognizer locationInView:manager.rootView]];
+        ret = [dropZone dropZoneIsActive:manager point:[recognizer locationInView:manager.rootView]];
     }
     else if([dropZone isKindOfClass:[UIView class]])
     {

--- a/Classes/AtkDragAndDropManager.m
+++ b/Classes/AtkDragAndDropManager.m
@@ -136,14 +136,14 @@ NSString *const AtkPasteboardNameDragAndDrop = @"com.comcast.bcv.draganddrop.pas
 {
     for(AtkDropZoneWrapper *dropZone in self.uninterestedDropZones)
     {
-        if([dropZone.dropZone respondsToSelector:@selector(dragStarted:)])
-            [dropZone.dropZone dragStarted:self];
+        if([dropZone.dropZone respondsToSelector:@selector(dropZoneDragStarted:)])
+            [dropZone.dropZone dropZoneDragStarted:self];
     }
     
     for(AtkDropZoneWrapper *dropZone in self.interestedDropZones)
     {
-        if([dropZone.dropZone respondsToSelector:@selector(dragStarted:)])
-            [dropZone.dropZone dragStarted:self];
+        if([dropZone.dropZone respondsToSelector:@selector(dropZoneDragStarted:)])
+            [dropZone.dropZone dropZoneDragStarted:self];
     }
     
     if([self.dragSource respondsToSelector:@selector(dragStarted:)])
@@ -157,14 +157,14 @@ NSString *const AtkPasteboardNameDragAndDrop = @"com.comcast.bcv.draganddrop.pas
 {
     for(AtkDropZoneWrapper *dropZone in self.uninterestedDropZones)
     {
-        if([dropZone.dropZone respondsToSelector:@selector(dragEnded:)])
-            [dropZone.dropZone dragEnded:self];
+        if([dropZone.dropZone respondsToSelector:@selector(dropZoneDragEnded:)])
+            [dropZone.dropZone dropZoneDragEnded:self];
     }
     
     for(AtkDropZoneWrapper *dropZone in self.interestedDropZones)
     {
-        if([dropZone.dropZone respondsToSelector:@selector(dragEnded:)])
-            [dropZone.dropZone dragEnded:self];
+        if([dropZone.dropZone respondsToSelector:@selector(dropZoneDragEnded:)])
+            [dropZone.dropZone dropZoneDragEnded:self];
     }
     
     if([self.dragSource respondsToSelector:@selector(dragEnded:)])
@@ -176,8 +176,8 @@ NSString *const AtkPasteboardNameDragAndDrop = @"com.comcast.bcv.draganddrop.pas
 
 - (void)dragEntered:(id<AtkDropZoneProtocol>)dropZone point:(CGPoint)point
 {
-    if([dropZone respondsToSelector:@selector(dragEntered:point:)])
-        [dropZone dragEntered:self point:point];
+    if([dropZone respondsToSelector:@selector(dropZoneDragEntered:point:)])
+        [dropZone dropZoneDragEntered:self point:point];
     
     if([self.dragSource respondsToSelector:@selector(dragEntered:dropZone:point:)])
         [self.dragSource dragEntered:self dropZone:dropZone point:point];
@@ -188,8 +188,8 @@ NSString *const AtkPasteboardNameDragAndDrop = @"com.comcast.bcv.draganddrop.pas
 
 - (void)dragExited:(id<AtkDropZoneProtocol>)dropZone point:(CGPoint)point
 {
-    if([dropZone respondsToSelector:@selector(dragExited:point:)])
-        [dropZone dragExited:self point:point];
+    if([dropZone respondsToSelector:@selector(dropZoneDragExited:point:)])
+        [dropZone dropZoneDragExited:self point:point];
     
     if([self.dragSource respondsToSelector:@selector(dragExited:dropZone:point:)])
         [self.dragSource dragExited:self dropZone:dropZone point:point];
@@ -200,8 +200,8 @@ NSString *const AtkPasteboardNameDragAndDrop = @"com.comcast.bcv.draganddrop.pas
 
 - (void)dragMoved:(id<AtkDropZoneProtocol>)dropZone point:(CGPoint)point
 {
-    if([dropZone respondsToSelector:@selector(dragMoved:point:)])
-        [dropZone dragMoved:self point:point];
+    if([dropZone respondsToSelector:@selector(dropZoneDragMoved:point:)])
+        [dropZone dropZoneDragMoved:self point:point];
     
     if([self.dragSource respondsToSelector:@selector(dragMoved:dropZone:point:)])
         [self.dragSource dragMoved:self dropZone:dropZone point:point];
@@ -212,8 +212,8 @@ NSString *const AtkPasteboardNameDragAndDrop = @"com.comcast.bcv.draganddrop.pas
 
 - (void)dragDropped:(id<AtkDropZoneProtocol>)dropZone point:(CGPoint)point
 {
-    if([dropZone respondsToSelector:@selector(dragDropped:point:)])
-        [dropZone dragDropped:self point:point];
+    if([dropZone respondsToSelector:@selector(dropZoneDragDropped:point:)])
+        [dropZone dropZoneDragDropped:self point:point];
     
     if([self.dragSource respondsToSelector:@selector(dragDropped:dropZone:point:)])
         [self.dragSource dragDropped:self dropZone:dropZone point:point];
@@ -375,7 +375,7 @@ NSString *const AtkPasteboardNameDragAndDrop = @"com.comcast.bcv.draganddrop.pas
         {
             for(id<AtkDropZoneProtocol> dropZone in dropZones)
             {
-                if([dropZone respondsToSelector:@selector(isInterested:)] && [dropZone isInterested:self])
+                if([dropZone respondsToSelector:@selector(dropZoneIsInterested:)] && [dropZone dropZoneIsInterested:self])
                 {
                     if(!interestedDropZones)
                         interestedDropZones = [NSMutableArray arrayWithCapacity:[dropZones count]];

--- a/Classes/AtkDropZoneProtocol.h
+++ b/Classes/AtkDropZoneProtocol.h
@@ -17,51 +17,51 @@
 /**
  * Should the drop zone be considered active for the manager and point.
  */
-- (BOOL)isActive:(AtkDragAndDropManager *)manager point:(CGPoint)point;
+- (BOOL)dropZoneIsActive:(AtkDragAndDropManager *)manager point:(CGPoint)point;
 
 /**
  * A drag has started, should we consider this drop zone. A drop zone that is considered
  * will receive calls, as appropriate, to isInterested, dragStarted and dragEnded but not
  * dragEntered, dragExited, dragMoved and dragDropped
  */
-- (BOOL)shouldDragStart:(AtkDragAndDropManager *)manager;
+- (BOOL)dropZoneShouldDragStart:(AtkDragAndDropManager *)manager;
 
 /**
- * A drag has started and shouldDragStart returned YES. Should we consider this drop zone interested in receiving
+ * A drag has started and shouldDropStart returned YES. Should we consider this drop zone interested in receiving
  * the following calls dragEntered, dragExited, dragMoved, dragDropped in addition to dragStarted and dragEnded.
  */
-- (BOOL)isInterested:(AtkDragAndDropManager *)manager;
+- (BOOL)dropZoneIsInterested:(AtkDragAndDropManager *)manager;
 
 /*
  * Called on all drop zones that responded YES to dragStarted when the drag operation has started. This will
- * be soon after shouldDragStart responds YES.
+ * be soon after shouldDropStart responds YES.
  */
-- (void)dragStarted:(AtkDragAndDropManager *)manager;
+- (void)dropZoneDragStarted:(AtkDragAndDropManager *)manager;
 
 /*
  * Called on all drop zones that responded YES to dragStarted when the drag operation has ended. This will
  * be called last in the lifecycle of AtkDragAndDrop.
  */
-- (void)dragEnded:(AtkDragAndDropManager *)manager;
+- (void)dropZoneDragEnded:(AtkDragAndDropManager *)manager;
 
 /*
  * Called when the drag has entered the drop zone.
  */
-- (void)dragEntered:(AtkDragAndDropManager *)manager point:(CGPoint)point;
+- (void)dropZoneDragEntered:(AtkDragAndDropManager *)manager point:(CGPoint)point;
 
 /*
  * Called when the drag has exited the drop zone.
  */
-- (void)dragExited:(AtkDragAndDropManager *)manager point:(CGPoint)point;
+- (void)dropZoneDragExited:(AtkDragAndDropManager *)manager point:(CGPoint)point;
 
 /*
  * Called when the drag is in the drop zone and has moved.
  */
-- (void)dragMoved:(AtkDragAndDropManager *)manager point:(CGPoint)point;
+- (void)dropZoneDragMoved:(AtkDragAndDropManager *)manager point:(CGPoint)point;
 
 /*
  * called when the drag is in the drop zone and has been dropped.
  */
-- (void)dragDropped:(AtkDragAndDropManager *)manager point:(CGPoint)point;
+- (void)dropZoneDragDropped:(AtkDragAndDropManager *)manager point:(CGPoint)point;
 
 @end

--- a/Examples/AtkDragAndDrop_Examples/Sample01/AtkSampleOneDropZoneScrollView.m
+++ b/Examples/AtkDragAndDrop_Examples/Sample01/AtkSampleOneDropZoneScrollView.m
@@ -44,48 +44,48 @@
     return self;
 }
 
-- (BOOL)shouldDragStart:(AtkDragAndDropManager *)manager
+- (BOOL)dropZoneShouldDragStart:(AtkDragAndDropManager *)manager
 {
     return YES;
 }
 
-- (void)dragStarted:(AtkDragAndDropManager *)manager
+- (void)dropZoneDragStarted:(AtkDragAndDropManager *)manager
 {
     //NSLog(@"AtkSampleOneDropZoneScrollView.dragStarted");
     [self autoScrollDragStarted];
 }
 
-- (BOOL)isInterested:(AtkDragAndDropManager *)manager
+- (BOOL)dropZoneIsInterested:(AtkDragAndDropManager *)manager
 {
     //NSLog(@"AtkSampleOneDropZoneScrollView.isInterested");
     return YES;
 }
 
-- (void)dragEnded:(AtkDragAndDropManager *)manager
+- (void)dropZoneDragEnded:(AtkDragAndDropManager *)manager
 {
     //NSLog(@"AtkSampleOneDropZoneScrollView.dragEnded");
     [self autoScrollDragEnded];
 }
 
-- (void)dragEntered:(AtkDragAndDropManager *)manager point:(CGPoint)point
+- (void)dropZoneDragEntered:(AtkDragAndDropManager *)manager point:(CGPoint)point
 {
     //NSLog(@"AtkSampleOneDropZoneScrollView.dragEntered");
     self.savedBackgroundColor = self.backgroundColor;
     self.backgroundColor = [UIColor blueColor];
 }
 
-- (void)dragExited:(AtkDragAndDropManager *)manager point:(CGPoint)point
+- (void)dropZoneDragExited:(AtkDragAndDropManager *)manager point:(CGPoint)point
 {
     //NSLog(@"AtkSampleOneDropZoneScrollView.dragExited");
     self.backgroundColor = self.savedBackgroundColor;
 }
 
-- (void)dragMoved:(AtkDragAndDropManager *)manager point:(CGPoint)point
+- (void)dropZoneDragMoved:(AtkDragAndDropManager *)manager point:(CGPoint)point
 {
     [self autoScrollDragMoved:[manager.rootView convertPoint:point toView:self]];
 }
 
-- (void)dragDropped:(AtkDragAndDropManager *)manager point:(CGPoint)point
+- (void)dropZoneDragDropped:(AtkDragAndDropManager *)manager point:(CGPoint)point
 {
     //NSLog(@"AtkSampleOneDropZoneScrollView.dragDropped");
     self.backgroundColor = [UIColor greenColor];

--- a/Examples/AtkDragAndDrop_Examples/Sample01/AtkSampleOneDropZoneView.m
+++ b/Examples/AtkDragAndDrop_Examples/Sample01/AtkSampleOneDropZoneView.m
@@ -25,12 +25,12 @@
     return self;
 }
 
-- (BOOL)shouldDragStart:(AtkDragAndDropManager *)manager
+- (BOOL)dropZoneShouldDragStart:(AtkDragAndDropManager *)manager
 {
     return YES;
 }
 
-- (BOOL)isInterested:(AtkDragAndDropManager *)manager
+- (BOOL)dropZoneIsInterested:(AtkDragAndDropManager *)manager
 {
     NSLog(@"AtkSampleOneDropZoneView.isInterested");
     
@@ -41,7 +41,7 @@
     return [tagValue isEqualToString:pasteboardString];
 }
 
-- (void)dragStarted:(AtkDragAndDropManager *)manager
+- (void)dropZoneDragStarted:(AtkDragAndDropManager *)manager
 {
     NSLog(@"AtkSampleOneDropZoneView.dragStarted");
     self.savedBackgroundColor = self.backgroundColor;
@@ -60,47 +60,38 @@
     }
 }
 
-- (void)dragEnded:(AtkDragAndDropManager *)manager
+- (void)dropZoneDragEnded:(AtkDragAndDropManager *)manager
 {
     NSLog(@"AtkSampleOneDropZoneView.dragEnded");
     [self performSelector:@selector(delayEnd) withObject:nil afterDelay:0.4];
+}
+
+- (void)dropZoneDragEntered:(AtkDragAndDropManager *)manager point:(CGPoint)point
+{
+    NSLog(@"AtkSampleOneDropZoneView.dragEntered");
+    self.backgroundColor = [UIColor orangeColor];
+}
+
+- (void)dropZoneDragExited:(AtkDragAndDropManager *)manager point:(CGPoint)point
+{
+    NSLog(@"AtkSampleOneDropZoneView.dragExited");
+    self.backgroundColor = [UIColor colorWithRed:0.9 green:0.9 blue:0.9 alpha:1.0];
+}
+
+- (void)dropZoneDragMoved:(AtkDragAndDropManager *)manager point:(CGPoint)point
+{
+    //NSLog(@"AtkSampleOneDropZoneView.dragMoved");
+}
+
+- (void)dropZoneDragDropped:(AtkDragAndDropManager *)manager point:(CGPoint)point
+{
+    NSLog(@"AtkSampleOneDropZoneView.dragDropped");
+    self.backgroundColor = [UIColor magentaColor];
 }
 
 - (void)delayEnd
 {
     self.backgroundColor = self.savedBackgroundColor;
 }
-
-- (void)dragEntered:(AtkDragAndDropManager *)manager point:(CGPoint)point
-{
-    NSLog(@"AtkSampleOneDropZoneView.dragEntered");
-    self.backgroundColor = [UIColor orangeColor];
-}
-
-- (void)dragExited:(AtkDragAndDropManager *)manager point:(CGPoint)point
-{
-    NSLog(@"AtkSampleOneDropZoneView.dragExited");
-    self.backgroundColor = [UIColor colorWithRed:0.9 green:0.9 blue:0.9 alpha:1.0];
-}
-
-- (void)dragMoved:(AtkDragAndDropManager *)manager point:(CGPoint)point
-{
-    //NSLog(@"AtkSampleOneDropZoneView.dragMoved");
-}
-
-- (void)dragDropped:(AtkDragAndDropManager *)manager point:(CGPoint)point
-{
-    NSLog(@"AtkSampleOneDropZoneView.dragDropped");
-    self.backgroundColor = [UIColor magentaColor];
-}
-
-/*
-// Only override drawRect: if you perform custom drawing.
-// An empty implementation adversely affects performance during animation.
-- (void)drawRect:(CGRect)rect
-{
-    // Drawing code
-}
-*/
 
 @end

--- a/Examples/AtkDragAndDrop_Examples/Sample02/AtkSampleTwoDropZoneScrollViewWrapper.m
+++ b/Examples/AtkDragAndDrop_Examples/Sample02/AtkSampleTwoDropZoneScrollViewWrapper.m
@@ -32,54 +32,54 @@
 {
 }
 
-- (BOOL)isActive:(AtkDragAndDropManager *)manager point:(CGPoint)point
+- (BOOL)dropZoneIsActive:(AtkDragAndDropManager *)manager point:(CGPoint)point
 {
     return [self.view isActiveDropZone:manager point:point];
 }
 
-- (BOOL)shouldDragStart:(AtkDragAndDropManager *)manager
+- (BOOL)dropZoneShouldDragStart:(AtkDragAndDropManager *)manager
 {
     NSLog(@"AtkSampleOneDropZoneScrollView.shouldDragStart");
     return YES;
 }
 
-- (void)dragStarted:(AtkDragAndDropManager *)manager
+- (void)dropZoneDragStarted:(AtkDragAndDropManager *)manager
 {
     NSLog(@"AtkSampleOneDropZoneScrollView.dragStarted");
     [self.view autoScrollDragStarted];
 }
 
-- (BOOL)isInterested:(AtkDragAndDropManager *)manager
+- (BOOL)dropZoneIsInterested:(AtkDragAndDropManager *)manager
 {
     NSLog(@"AtkSampleOneDropZoneScrollView.isInterested");
     return YES;
 }
 
-- (void)dragEnded:(AtkDragAndDropManager *)manager
+- (void)dropZoneDragEnded:(AtkDragAndDropManager *)manager
 {
     NSLog(@"AtkSampleOneDropZoneScrollView.dragEnded");
     [self.view autoScrollDragEnded];
 }
 
-- (void)dragEntered:(AtkDragAndDropManager *)manager point:(CGPoint)point
+- (void)dropZoneDragEntered:(AtkDragAndDropManager *)manager point:(CGPoint)point
 {
     NSLog(@"AtkSampleOneDropZoneScrollView.dragEntered");
     self.savedBackgroundColor = self.view.backgroundColor;
     self.view.backgroundColor = [UIColor blueColor];
 }
 
-- (void)dragExited:(AtkDragAndDropManager *)manager point:(CGPoint)point
+- (void)dropZoneDragExited:(AtkDragAndDropManager *)manager point:(CGPoint)point
 {
     NSLog(@"AtkSampleOneDropZoneScrollView.dragExited");
     self.view.backgroundColor = self.savedBackgroundColor;
 }
 
-- (void)dragMoved:(AtkDragAndDropManager *)manager point:(CGPoint)point
+- (void)dropZoneDragMoved:(AtkDragAndDropManager *)manager point:(CGPoint)point
 {
     [self.view autoScrollDragMoved:[manager.rootView convertPoint:point toView:self.view]];
 }
 
-- (void)dragDropped:(AtkDragAndDropManager *)manager point:(CGPoint)point
+- (void)dropZoneDragDropped:(AtkDragAndDropManager *)manager point:(CGPoint)point
 {
     NSLog(@"AtkSampleOneDropZoneScrollView.dragDropped");
     self.view.backgroundColor = [UIColor greenColor];

--- a/Examples/AtkDragAndDrop_Examples/Sample02/AtkSampleTwoDropZoneWrapper.m
+++ b/Examples/AtkDragAndDrop_Examples/Sample02/AtkSampleTwoDropZoneWrapper.m
@@ -33,17 +33,17 @@
     
 }
 
-- (BOOL)isActive:(AtkDragAndDropManager *)manager point:(CGPoint)point
+- (BOOL)dropZoneIsActive:(AtkDragAndDropManager *)manager point:(CGPoint)point
 {
     return [self.view isActiveDropZone:manager point:point];
 }
 
-- (BOOL)shouldDragStart:(AtkDragAndDropManager *)manager
+- (BOOL)dropZoneShouldDragStart:(AtkDragAndDropManager *)manager
 {
     return YES;
 }
 
-- (BOOL)isInterested:(AtkDragAndDropManager *)manager
+- (BOOL)dropZoneIsInterested:(AtkDragAndDropManager *)manager
 {
     //NSLog(@"AtkSampleOneDropZoneView.dragStarted");
     UIPasteboard *pastebaord = manager.pasteboard;
@@ -53,7 +53,7 @@
     return [tagValue isEqualToString:pasteboardString];
 }
 
-- (void)dragStarted:(AtkDragAndDropManager *)manager
+- (void)dropZoneDragStarted:(AtkDragAndDropManager *)manager
 {
     //NSLog(@"AtkSampleOneDropZoneView.dragStarted");
     self.savedBackgroundColor = self.view.backgroundColor;
@@ -72,38 +72,38 @@
     }
 }
 
-- (void)dragEnded:(AtkDragAndDropManager *)manager
+- (void)dropZoneDragEnded:(AtkDragAndDropManager *)manager
 {
     //NSLog(@"AtkSampleOneDropZoneView.dragEnded");
     [self performSelector:@selector(delayEnd) withObject:nil afterDelay:0.4];
 }
 
-- (void)delayEnd
-{
-    self.view.backgroundColor = self.savedBackgroundColor;
-}
-
-- (void)dragEntered:(AtkDragAndDropManager *)manager point:(CGPoint)point
+- (void)dropZoneDragEntered:(AtkDragAndDropManager *)manager point:(CGPoint)point
 {
     //NSLog(@"AtkSampleOneDropZoneView.dragEntered");
     self.view.backgroundColor = [UIColor orangeColor];
 }
 
-- (void)dragExited:(AtkDragAndDropManager *)manager point:(CGPoint)point
+- (void)dropZoneDragExited:(AtkDragAndDropManager *)manager point:(CGPoint)point
 {
     //NSLog(@"AtkSampleOneDropZoneView.dragExited");
     self.view.backgroundColor = [UIColor colorWithRed:0.9 green:0.9 blue:0.9 alpha:1.0];
 }
 
-- (void)dragMoved:(AtkDragAndDropManager *)manager point:(CGPoint)point
+- (void)dropZoneDragMoved:(AtkDragAndDropManager *)manager point:(CGPoint)point
 {
     //NSLog(@"AtkSampleOneDropZoneView.dragMoved");
 }
 
-- (void)dragDropped:(AtkDragAndDropManager *)manager point:(CGPoint)point
+- (void)dropZoneDragDropped:(AtkDragAndDropManager *)manager point:(CGPoint)point
 {
     //NSLog(@"AtkSampleOneDropZoneView.dragDropped");
     self.view.backgroundColor = [UIColor magentaColor];
+}
+
+- (void)delayEnd
+{
+    self.view.backgroundColor = self.savedBackgroundColor;
 }
 
 @end

--- a/Examples/AtkDragAndDrop_Examples/Sample02/AtkSampleTwoViewController.m
+++ b/Examples/AtkDragAndDrop_Examples/Sample02/AtkSampleTwoViewController.m
@@ -119,9 +119,9 @@
 {
     BOOL ret = false;
     
-    if([dropZone respondsToSelector:@selector(isActive:point:)])
+    if([dropZone respondsToSelector:@selector(dropZoneIsActive:point:)])
     {
-        ret = [dropZone isActive:manager point:[recognizer locationInView:manager.rootView]];
+        ret = [dropZone dropZoneIsActive:manager point:[recognizer locationInView:manager.rootView]];
     }
     
     return ret;


### PR DESCRIPTION
You cannot make a view both a drop zone and a drag source due to naming conflcts in the protocols. This pull request fixes that by prefixing all the drop zone methods with “dropZone”.