### PR TITLE
Use drawViewHierarchy to render shadow image

### DIFF
--- a/Classes/UIView+AtkImage.m
+++ b/Classes/UIView+AtkImage.m
@@ -14,7 +14,12 @@
 - (UIImage*)imageFromView
 {
     UIGraphicsBeginImageContextWithOptions(self.bounds.size, self.opaque, 0.0);
-    [self.layer renderInContext:UIGraphicsGetCurrentContext()];
+    
+    if ([self respondsToSelector:@selector(drawViewHierarchyInRect:afterScreenUpdates:)]) {
+        [self drawViewHierarchyInRect:self.bounds afterScreenUpdates:YES];
+    } else {
+        [self.layer renderInContext:UIGraphicsGetCurrentContext()];
+    }
     
     UIImage * img = UIGraphicsGetImageFromCurrentImageContext();
     


### PR DESCRIPTION
The call to renderInContext does not work for all controls, particularly the track view in UISlider. In iOS7+, the correct way to render a UIView to an image is to use drawViewHierarchy. It is faster and more reliable.
