### PR TITLE
Auto-scroll even when not in drop zone

### DIFF
--- a/Classes/AtkDragAndDropManager.h
+++ b/Classes/AtkDragAndDropManager.h
@@ -69,6 +69,11 @@ extern NSString *const AtkPasteboardNameDragAndDrop;
 @property (weak, nonatomic, readonly) UIPasteboard* pasteboard;
 
 /**
+ * The scroll view to auto scroll
+ */
+@property (weak, nonatomic) UIScrollView* autoScrollView;
+
+/**
  * The root UIView as set by the call to start:(UIView *) or the UIApplication keyWindow
  * by default. All the players in the drag and drop scenerio must be descendants of rootView.
  */

--- a/Classes/AtkDragAndDropManager.m
+++ b/Classes/AtkDragAndDropManager.m
@@ -151,6 +151,9 @@ NSString *const AtkPasteboardNameDragAndDrop = @"com.comcast.bcv.draganddrop.pas
     
     if(_delegate && [_delegate respondsToSelector:@selector(dragStarted:)])
         [_delegate dragStarted:self];
+    
+    if(_autoScrollView)
+        [_autoScrollView autoScrollDragStarted];
 }
 
 - (void)dragEnded
@@ -172,6 +175,9 @@ NSString *const AtkPasteboardNameDragAndDrop = @"com.comcast.bcv.draganddrop.pas
     
     if(_delegate && [_delegate respondsToSelector:@selector(dragEnded:)])
         [_delegate dragEnded:self];
+    
+    if(_autoScrollView)
+        [_autoScrollView autoScrollDragEnded];
 }
 
 - (void)dragEntered:(id<AtkDropZoneProtocol>)dropZone point:(CGPoint)point
@@ -346,6 +352,12 @@ NSString *const AtkPasteboardNameDragAndDrop = @"com.comcast.bcv.draganddrop.pas
             dropZone.isActive = NO;
             [self dragExited:dropZone.dropZone point:pointInRootView];
         }
+    }
+    
+    if(_autoScrollView)
+    {
+        CGPoint pointInScrollView = [_autoScrollView convertPoint:pointInRootView fromView:self.rootView];
+        [_autoScrollView autoScrollDragMoved:pointInScrollView];
     }
 }
 

--- a/Examples/AtkDragAndDrop_Examples/Sample01/AtkSampleOneDropZoneScrollView.m
+++ b/Examples/AtkDragAndDrop_Examples/Sample01/AtkSampleOneDropZoneScrollView.m
@@ -52,7 +52,6 @@
 - (void)dropZoneDragStarted:(AtkDragAndDropManager *)manager
 {
     //NSLog(@"AtkSampleOneDropZoneScrollView.dragStarted");
-    [self autoScrollDragStarted];
 }
 
 - (BOOL)dropZoneIsInterested:(AtkDragAndDropManager *)manager
@@ -64,7 +63,6 @@
 - (void)dropZoneDragEnded:(AtkDragAndDropManager *)manager
 {
     //NSLog(@"AtkSampleOneDropZoneScrollView.dragEnded");
-    [self autoScrollDragEnded];
 }
 
 - (void)dropZoneDragEntered:(AtkDragAndDropManager *)manager point:(CGPoint)point
@@ -82,7 +80,6 @@
 
 - (void)dropZoneDragMoved:(AtkDragAndDropManager *)manager point:(CGPoint)point
 {
-    [self autoScrollDragMoved:[manager.rootView convertPoint:point toView:self]];
 }
 
 - (void)dropZoneDragDropped:(AtkDragAndDropManager *)manager point:(CGPoint)point

--- a/Examples/AtkDragAndDrop_Examples/Sample01/AtkSampleOneViewController.m
+++ b/Examples/AtkDragAndDrop_Examples/Sample01/AtkSampleOneViewController.m
@@ -50,6 +50,8 @@
     CGRect viewParentFrame = _viewParent.frame;
     
     _scroller.contentSize = viewParentFrame.size;
+    self.dragAndDropManager.autoScrollView = _scroller;
+    
     // Do any additional setup after loading the view from its nib.
 }
 

--- a/Examples/AtkDragAndDrop_Examples/Sample02/AtkSampleTwoDropZoneScrollViewWrapper.m
+++ b/Examples/AtkDragAndDrop_Examples/Sample02/AtkSampleTwoDropZoneScrollViewWrapper.m
@@ -46,7 +46,6 @@
 - (void)dropZoneDragStarted:(AtkDragAndDropManager *)manager
 {
     NSLog(@"AtkSampleOneDropZoneScrollView.dragStarted");
-    [self.view autoScrollDragStarted];
 }
 
 - (BOOL)dropZoneIsInterested:(AtkDragAndDropManager *)manager
@@ -58,7 +57,6 @@
 - (void)dropZoneDragEnded:(AtkDragAndDropManager *)manager
 {
     NSLog(@"AtkSampleOneDropZoneScrollView.dragEnded");
-    [self.view autoScrollDragEnded];
 }
 
 - (void)dropZoneDragEntered:(AtkDragAndDropManager *)manager point:(CGPoint)point
@@ -76,7 +74,6 @@
 
 - (void)dropZoneDragMoved:(AtkDragAndDropManager *)manager point:(CGPoint)point
 {
-    [self.view autoScrollDragMoved:[manager.rootView convertPoint:point toView:self.view]];
 }
 
 - (void)dropZoneDragDropped:(AtkDragAndDropManager *)manager point:(CGPoint)point

--- a/Examples/AtkDragAndDrop_Examples/Sample02/AtkSampleTwoViewController.m
+++ b/Examples/AtkDragAndDrop_Examples/Sample02/AtkSampleTwoViewController.m
@@ -47,6 +47,8 @@
     CGRect viewParentFrame = _viewParent.frame;
     
     _scroller.contentSize = viewParentFrame.size;
+    self.dragAndDropManager.autoScrollView = _scroller;
+    
     // Do any additional setup after loading the view from its nib.
 }
 


### PR DESCRIPTION
This PR auto-scrolls the scroll view even when the dragged view is not in a drop zone. This lets you use auto-scroll to get to a drop zone. This is accomplished via a new `autoScrollView` property in `AtkDragAndDropManager` that automatically handles passing the appropriate messages to the scroll view -- the delegate no longer has to do this.
